### PR TITLE
Added a command line option to specify a path to git.

### DIFF
--- a/converter.rb
+++ b/converter.rb
@@ -69,7 +69,8 @@ class Converter
 	end
 
 	def self.git_command(command, *options)
-		parts = %w(git)
+		parts = []
+		parts << quote_param(:git)
 		parts << command
 		[*options].each{|param| parts << param}
 		cmd = parts.join(' ')

--- a/options.rb
+++ b/options.rb
@@ -9,6 +9,7 @@ module Options
 	$options.usename = ""
 	$options.password = ""
 	$options.vault_client = "C:\\Program Files\\SourceGear\\Vault Client\\vault.exe"
+	$options.git = "git"
 	$options.logfile = "vault2git.log"
 	
 	OptionParser.new do |opts|
@@ -21,6 +22,7 @@ module Options
 	  opts.on('-u', '--username [username]', 'The repository user') {|val| $options.username = val}
 	  opts.on('-p', '--password [password]', 'The repository user\'s password') {|val| $options.password = val}
 	  opts.on('--vault-client-path path-to-vault.exe', "Path to vault.exe, defaults to #{$options.vault_client}") {|val| $options.vault_client = val}
+	  opts.on('--git-path path-to-git.exe', "Path to git.exe, defaults to #{$options.git}") {|val| $options.git = val}
 	  opts.on('--logfile filename', "File to log to (defaults to #{$options.logfile})") {|val| $options.logfile = val}
 
 	  opts.on('-h', '--help', 'Display this help screen') do


### PR DESCRIPTION
Hi,

I didn't have git in my path which was causing when I tried to import a vault repository. This commit adds a new command line option "--git-path" which lets users specify a path to git on their computer. 
