### PR TITLE
Fixed missing required gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source :rubygems
 
 gem 'nokogiri', '1.4.4'
+gem 'log4r'


### PR DESCRIPTION
log4r is required and isn't included in the gemfile.
